### PR TITLE
feat-create-DateRenderer-component

### DIFF
--- a/packages/react-composable-calendar/src/components/day-renderer.tsx
+++ b/packages/react-composable-calendar/src/components/day-renderer.tsx
@@ -1,0 +1,16 @@
+import type { ComponentProps, ReactNode } from "react";
+import { useDayContext } from "../contexts/day.js";
+
+import type { PlainDate } from "../temporal.js";
+
+export type DayRendererProps = ComponentProps<"div"> & {
+  render: (props: { day: PlainDate }) => ReactNode;
+};
+
+export function DayRenderer(props: DayRendererProps) {
+  const { render, ...rest } = props;
+
+  const dayContext = useDayContext();
+  const day = dayContext.day;
+  return <div {...rest}>{render({ day })}</div>;
+}

--- a/packages/react-composable-calendar/src/components/index.tsx
+++ b/packages/react-composable-calendar/src/components/index.tsx
@@ -14,4 +14,5 @@ export * from "./month-title.js";
 export * from "./days.js";
 export * from "./day.js";
 export * from "./day-label.js";
+export * from "./day-renderer.js";
 export * from "./form-input.js";


### PR DESCRIPTION
As I suggested in [this issue](https://github.com/feelixe/react-composable-calendar/issues/7), I've created a simple `DayRenderer` component. On my local, this is how I'm using it:
```jsx
<Calendar.Root mode="single">
    <Calendar.View>
        <Calendar.Days className={css.days}>
            <Calendar.Day className={css.day}>
                <Calendar.DayInRange />
                <Calendar.DayLabel />
                <Calendar.DayRenderer
                    render={({ dayjsDate }) => (
                        <DaysEvents date={dayjsDate} />
                    )}
                />
            </Calendar.Day>
        </Calendar.Days>
    </Calendar.View>
</Calendar>

function DaysEvents({ date }: { date: Dayjs }) {
    return <div>{date.format("YYYY-MM-DD")}</div>;
}
```

> [!NOTE]
> In `packages/react-composable-calendar/src/components/day-renderer.tsx` I'm passing a `Temporal.PlainDate` to the render function, but it appears to get transformed into a `dayjs` date, somehow. I'm not familiar enough with the polyfill, Temporal or dayjs to explain why.
> Regardless, whatever the shape of the date would be, it would be useful to be able to render content based on the date.